### PR TITLE
Add Muon optimizer

### DIFF
--- a/test/optim/test_muon.py
+++ b/test/optim/test_muon.py
@@ -1,0 +1,29 @@
+# Owner(s): ["module: optimizer"]
+from torch.testing._internal.common_utils import TestCase, instantiate_parametrized_tests, load_tests
+import torch
+from torch.optim import Muon
+
+load_tests = load_tests
+
+
+def rosenbrock(tensor):
+    x, y = tensor
+    return (1 - x) ** 2 + 100 * (y - x**2) ** 2
+
+
+class TestMuon(TestCase):
+    def test_basic_convergence(self):
+        param = torch.nn.Parameter(torch.tensor([[0.8, 0.7]], dtype=torch.float32))
+        optim = Muon([param], lr=0.1)
+        for _ in range(50):
+            optim.zero_grad()
+            loss = rosenbrock(param.view(-1))
+            loss.backward()
+            optim.step()
+        self.assertLess(loss.item(), 1.0)
+
+
+instantiate_parametrized_tests(TestMuon)
+
+if __name__ == "__main__":
+    print("These tests should be run through test/test_optim.py instead")

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from optim.test_lrscheduler import TestLRScheduler  # noqa: F401
 from optim.test_optim import TestDifferentiableOptimizer  # noqa: F401
 from optim.test_swa_utils import TestSWAUtils  # noqa: F401
+from optim.test_muon import TestMuon  # noqa: F401
 
 import torch
 from torch.nn import Parameter

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -8,6 +8,7 @@ future.
 
 from torch.optim import lr_scheduler as lr_scheduler, swa_utils as swa_utils
 from torch.optim._adafactor import Adafactor as Adafactor
+from torch.optim.muon import Muon as Muon
 from torch.optim.adadelta import Adadelta as Adadelta
 from torch.optim.adagrad import Adagrad as Adagrad
 from torch.optim.adam import Adam as Adam
@@ -59,5 +60,6 @@ __all__ = [
     "Rprop",
     "SGD",
     "SparseAdam",
+    "Muon",
     "swa_utils",
 ]

--- a/torch/optim/muon.py
+++ b/torch/optim/muon.py
@@ -1,0 +1,77 @@
+# mypy: allow-untyped-defs
+"""Muon optimizer implementation.
+
+This is a minimal single-device implementation of the Muon optimizer
+based on https://github.com/KellerJordan/Muon.
+"""
+
+from typing import Iterable, Optional
+
+import torch
+from torch import Tensor
+from .optimizer import Optimizer, ParamsT
+
+__all__ = ["Muon"]
+
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
+    """Compute an approximate orthogonalization of ``G`` using
+    Newton--Schulz iterations.
+    """
+    assert G.ndim >= 2
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.to(torch.bfloat16)
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X.to(G.dtype)
+
+
+def muon_update(
+    grad: Tensor,
+    momentum: Tensor,
+    beta: float = 0.95,
+    ns_steps: int = 5,
+    nesterov: bool = True,
+) -> Tensor:
+    momentum.lerp_(grad, 1 - beta)
+    update = grad.lerp_(momentum, beta) if nesterov else momentum
+    if update.ndim == 4:
+        update = update.view(len(update), -1)
+    update = zeropower_via_newtonschulz5(update, steps=ns_steps)
+    update *= max(1, grad.size(-2) / grad.size(-1)) ** 0.5
+    return update
+
+
+class Muon(Optimizer):
+    """Implements the Muon optimizer for orthogonal weight updates."""
+
+    def __init__(self, params: ParamsT, lr: float = 0.02, weight_decay: float = 0.0, momentum: float = 0.95) -> None:
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure: Optional[callable] = None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                state = self.state[p]
+                if len(state) == 0:
+                    state["momentum_buffer"] = torch.zeros_like(p)
+                update = muon_update(p.grad, state["momentum_buffer"], beta=group["momentum"])
+                p.mul_(1 - group["lr"] * group["weight_decay"])
+                p.add_(update.reshape_as(p), alpha=-group["lr"])
+
+        return loss


### PR DESCRIPTION
## Summary
- add a new Muon optimizer implementation
- expose Muon in the optim package
- include a basic convergence test

## Testing
- `python test/run_test.py --pytest test/optim/test_muon.py -v` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6877304fa174832e91c40ee80fc562e2